### PR TITLE
move capistrano to development dependency

### DIFF
--- a/env_lint.gemspec
+++ b/env_lint.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'formatador'
-  spec.add_runtime_dependency 'capistrano', '~> 2.9'
 
+  spec.add_development_dependency 'capistrano', '~> 2.9'
   spec.add_development_dependency 'rspec', '3.0.0.beta1'
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'

--- a/lib/env_lint/version.rb
+++ b/lib/env_lint/version.rb
@@ -1,3 +1,3 @@
 module EnvLint
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end


### PR DESCRIPTION
This gem is useful even when capistrano is not in the picture. The gemspec dependency for capistrano is necessary only for running the gem's own specs.

Moving the dependency from runtime to development moves capistrano out of the codebase when env_lint is bundled. 

The specs still pass...

``` shell
env-lint (master)$ rspec spec
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
...........................................

Finished in 0.03549 seconds
43 examples, 0 failures
[Coveralls] Outside the Travis environment, not sending data.
```
